### PR TITLE
fixed 'domaine' spelling to 'domain'

### DIFF
--- a/app/tools.json
+++ b/app/tools.json
@@ -467,7 +467,7 @@
             "title": "Pixabay",
             "image": "pixabay.jpg",
             "content": [
-                "A search engine for public domaine images."
+                "A search engine for public domain images."
             ],
             "tags": [
                 "images"


### PR DESCRIPTION
as told in https://www.merriam-webster.com/dictionary/domaine, domaine means vineyard, here domain is the appropriate spelling.